### PR TITLE
NecrosCopy: Assign mark before using it

### DIFF
--- a/ua.NecrosCopy.lua
+++ b/ua.NecrosCopy.lua
@@ -589,6 +589,7 @@ function splitbreak(subs,sel)
 				},{"Spaces","Tags","Marker","Skip","Cancel"},{close='Cancel'})
 			end
 			if P=="Cancel" then ak() end
+			breakit=false nmbr=rez.num mark=rez.mark
 			text=text:gsub("\\N","")
 			if P=="Spaces" then text=textreplace(text," "," \\N") end
 			if P=="Tags" then
@@ -602,7 +603,6 @@ function splitbreak(subs,sel)
 				text=stags..after
 			end
 			if rez.remember then applytoall=P end
-			breakit=false nmbr=rez.num mark=rez.mark
 			text=text:gsub("({\\[^}]*}) *\\N","\\N%1")
 		end
 	


### PR DESCRIPTION
Splitting by marker currently produces this error:
```
Lua reported a runtime error:
    File "/home/bucket/.aegisub/automation/autoload/ua.NecrosCopy.lua", line 1231
<anonymous function at lines 1187-1232>
    File "/home/bucket/.aegisub/automation/autoload/ua.NecrosCopy.lua", line 601
splitbreak
    File "/home/bucket/.aegisub/automation/autoload/ua.NecrosCopy.lua", line 827
esc
attempt to index local 'str' (a nil value)
```
It is caused by `mark` being used before it is first assigned to. This patch assigns a value to `mark` before it is first used.