### PR TITLE
Following user defined rounding rules for vector clips

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -222,7 +222,7 @@
         }
       },
       "changelog": {
-		"4.5.2": ["Follow user defined rounding for vector clips"],
+	"4.5.2": ["Follow user defined rounding for vector clips"],
         "4.5.1": ["Support for subpixel vector clips"],
         "4.5.0": ["Check the Updates page"]
       }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -216,7 +216,7 @@
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "23051f12ae6a9b0e4af8c90007db95339060d93a"
+              "sha1": "e7a4e9f28363aa2deb27c3eab112dbd7d2d1ac73"
             }
           ]
         }

--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -209,19 +209,20 @@
       "description": "Advanced metamorphosis of multidimensional coordinates",
       "channels": {
         "master": {
-          "version": "4.5.1",
-          "released": "2020-08-22",
+          "version": "4.5.2",
+          "released": "2022-04-24",
           "default": true,
           "files": [
             {
               "name": ".lua",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "2fb823ab1f22b38d1181beacc73ef663874ad0fe"
+              "sha1": "23051f12ae6a9b0e4af8c90007db95339060d93a"
             }
           ]
         }
       },
       "changelog": {
+		"4.5.2": ["Follow user defined rounding for vector clips"],
         "4.5.1": ["Support for subpixel vector clips"],
         "4.5.0": ["Check the Updates page"]
       }

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -1450,7 +1450,6 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    rrr=rr
 		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -5,12 +5,12 @@ script_name="Hyperdimensional Relocator"
 script_description="Advanced metamorphosis of multidimensional coordinates"
 script_author="reanimated"
 script_url="http://unanimated.hostfree.pw/ts/relocator.lua"
-script_version="4.5"
+script_version="4.5.2"
 script_namespace="ua.Relocator"
 
 local haveDepCtrl,DependencyControl,depRec=pcall(require,"l0.DependencyControl")
 if haveDepCtrl then
-	script_version="4.5.1"
+	script_version="4.5.2"
 	depRec=DependencyControl{feed="https://raw.githubusercontent.com/unanimated/luaegisub/master/DependencyControl.json"}
 end
 
@@ -1450,7 +1450,7 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    if klip:match("m") then rrr=0 else rrr=rr end
+		    rrr=rr
 		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end

--- a/ua.Relocator.lua
+++ b/ua.Relocator.lua
@@ -1450,7 +1450,7 @@ function modifier(subs,sel,act)
 		end
 		if text:match("\\i?clip") and res.rnd=="all" or text:match("\\i?clip") and res.rnd=="clip" then
 		  for klip in text:gmatch("\\i?clip%([^%)]+%)") do
-		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rrr) end)
+		    klip2=klip:gsub("([%d.-]+)",function(c) return round(c,rr) end)
 		    text=text:gsub(esc(klip),klip2)
 		  end
 		end


### PR DESCRIPTION
[libass](https://github.com/libass/libass) can take and make use of vector clips with decimals points.
Rounding vector clips down to integers regardless of user input is not necessary anymore, more like destructive.
(new pr because I left an unnecesary tab in the json)