### PR TITLE
FadeWorkS: Fix off-by-one error for \ko fades

### DIFF
--- a/ua.FadeWorks.lua
+++ b/ua.FadeWorks.lua
@@ -490,12 +490,12 @@ function koko_da(subs,sel)
 	if not res.word then
 		matches=re.find(text,"[\\w[:punct:]][\\s\\\\*]*")
 		len=#matches
-		if fadin>=40 then ko=round(fadin/(len-1))/10 else ko=fadin end
+		if fadin>=40 then ko=round(fadin/len)/10 else ko=fadin end
 		text=re.sub(text,"([\\w[:punct:]])","{\\\\ko"..ko.."}\\1")
 	else	--word
 		matches=re.find(text,"[\\w[:punct:]]+[\\s\\\\*]*")
 		len=#matches
-		if fadin>=40 then ko=round(fadin/(len-1)/10) else ko=fadin end
+		if fadin>=40 then ko=round(fadin/len/10) else ko=fadin end
 		text=re.sub(text,"([\\w[:punct:]]+)","{\\\\ko"..ko.."}\\1")
 	end
 


### PR DESCRIPTION
`koko_da` determines the \ko duration by dividing the "Fade in" value by the number of word characters and punctuation if the "Fade in" value is at least 40.

`len` contains the number of word characters and punctuation, but 1 is erroneously subtracted from it before the division, resulting in durations that are too long to fit the "Fade in" duration. The fix is to remove the subtraction and simply divide by `len`.