### PR TITLE
Fix C++ exception error in Significance 'make style from act. line' stuff function.

### DIFF
--- a/ua.Significance.lua
+++ b/ua.Significance.lua
@@ -765,10 +765,10 @@ function stuff(subs,sel,act)
 	sr.color2="&H"..a2..color2.."&"
 	sr.color3="&H"..a3..color3.."&"
 	sr.color4="&H"..a4..color4.."&"
-	sr.bold=tags:match("\\b([01])") or sr.bold 
-	sr.italic=tags:match("\\i([01])") or sr.italic 
-	sr.underline=tags:match("\\u([01])") or sr.underline 
-	sr.strikeout=tags:match("\\s([01])") or sr.strikeout 
+	sr.bold=makebool(tags:match("\\b([01])") or sr.bold)
+	sr.italic=makebool(tags:match("\\i([01])") or sr.italic)
+	sr.underline=makebool(tags:match("\\u([01])") or sr.underline)
+	sr.strikeout=makebool(tags:match("\\s([01])") or sr.strikeout)
 	sr.fontname=tags:match("\\fn([^\\}]+)") or sr.fontname
 	sr.fontsize=tags:match("\\fs(%d+)") or sr.fontsize 
 	sr.scale_x=tags:match("\\fscx([^\\}]+)") or sr.scale_x
@@ -813,7 +813,7 @@ function stuff(subs,sel,act)
 		    st=subs[i]
 		    if st.name==sr.name then t_error("Style with that name already exists",1) end
 		end
-		if subs[i].class=="dialogue" then subs.insert(i,sr)
+		if subs[i].class=="dialogue" then subs[-i] = sr
 		for z,s in ipairs(sel) do sel[z]=sel[z]+1 end
 		break end
 	end
@@ -2354,6 +2354,7 @@ end
 function loggtab(m) m=tf(m) or "nil" aegisub.log("\n {"..table.concat(m,', ').."}") end
 function progress(msg) if aegisub.progress.is_cancelled() then ak() end aegisub.progress.title(msg) end
 function t_error(message,cancel) ADD({{class="label",label=message}},{"OK"},{close='OK'}) if cancel then ak() end end
+function makebool(val) if type(val) == "string" then return val == "1" else return val end end
 
 function addtag3(tg,txt)
 	no_tf=txt:gsub("\\t%b()","")

--- a/ua.Significance.lua
+++ b/ua.Significance.lua
@@ -778,9 +778,9 @@ function stuff(subs,sel,act)
 	sr.outline=tags:match("\\bord([^\\}]+)") or sr.outline
 	sr.shadow=tags:match("\\shad([^\\}]+)") or sr.shadow
 	sr.align=tags:match("\\an(%d)") or sr.align
-	sr.margin_l=line.margin_l or sr.margin_l
-	sr.margin_r=line.margin_r or sr.margin_r
-	sr.margin_t=line.margin_t or sr.margin_t
+	sr.margin_l=(line.margin_l ~= 0 and line.margin_l) or sr.margin_l
+	sr.margin_r=(line.margin_r ~= 0 and line.margin_r) or sr.margin_r
+	sr.margin_t=(line.margin_t ~= 0 and line.margin_t) or sr.margin_t
 	
 	stylename={{class="label",label="Style Name"},{y=1,class="edit",name="snam",value=""},
 	{y=2,class="checkbox",name="switch",label="switch to new style",value=true},


### PR DESCRIPTION
Aegisub version: `Aegisub 9676-migration02-168b6f679`

Example line:
`Dialogue: 0,0:02:00.60,0:02:00.64,Default,,0,0,0,,{\b1}test`

When trying to make a new style from this line using Significance, it fails with:
`Lua reported a runtime error: C++ exception`

Changing the line insertion code to `subs[-i] = sr` in line 816, reveals another error message:
`Invalid or missing field 'bold' in 'style' class subtitle line (expected boolean)`

Something must have changed, and now Aegisub expects those boolean fields to actually be boolean type. I fixed it by converting those 4 boolean types to an actual boolean typed value.
I also fixed the margins, because it never used the margins from the style even if the margins on the lines were left 0.